### PR TITLE
Fix: ensure HTML/CSS is not output on every page load including AJAX requests

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -149,22 +149,21 @@ function pressable_cache_management_display_settings_page()
 
     </style>
       </div><?php
-}
+    /** Hide CDN tab if the endpoint is not found **/
 
-/** Hide CDN tab if the endpoint is not found **/
+    $cdn_api_state = get_option('cdn-api-state'); //See ln 256 api_connection.php
+    if ($cdn_api_state == 'Not Found')
+    {
+    ?>
+        <style type="text/css">
+            /** Hide CDN tab **/
+           a.nav-tab.nav-tab-cdn {
+        display: none !important;
+    }
 
-$cdn_api_state = get_option('cdn-api-state'); //See ln 256 api_connection.php
-if ($cdn_api_state == 'Not Found')
-{
-?>
-    <style type="text/css">
-        /** Hide CDN tab **/
-       a.nav-tab.nav-tab-cdn {
-    display: none !important;
-}
-
-    </style>
-    <?php
+        </style>
+        <?php
+    }
 }
 
 // Display footer message with Pressable branding


### PR DESCRIPTION
Instead, only output it on the settings page interface.

This ensures AJAX requests from other plugins don't

cc @otarhe who may be familiar with the original commit (7b16e69469063a6855d46824c86e29467b9304dc).

Fixes #12