### PR TITLE
Security, performance & PHP 8.1 audit - 23 findings fixed

### DIFF
--- a/admin/admin-menu.php
+++ b/admin/admin-menu.php
@@ -58,7 +58,7 @@ function pressable_cache_management_add_toplevel_menu()
     $remove_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
    
     
-if ($remove_pressable_branding_tab_options && 'disable'  == $remove_pressable_branding_tab_options['branding_on_off_radio_button'] )
+if ( is_array( $remove_pressable_branding_tab_options ) && isset( $remove_pressable_branding_tab_options['branding_on_off_radio_button'] ) && 'disable' === $remove_pressable_branding_tab_options['branding_on_off_radio_button'] )
 {
 
         add_menu_page(esc_html__('Cache Management Settings', 'pressable_cache_management') , esc_html__('Cache Control', 'pressable_cache_management') , 'manage_options', 'pressable_cache_management', 'pressable_cache_management_display_settings_page',

--- a/admin/custom-functions/cache-purge-admin-bar.php
+++ b/admin/custom-functions/cache-purge-admin-bar.php
@@ -37,6 +37,7 @@ function cache_purge_action_js() { ?>
 	 jQuery("li#wp-admin-bar-cache-purge .ab-item").on( "click", function() {
 		var data = {
 					  'action': 'pressable_cache_purge',
+					  '_ajax_nonce': '<?php echo esc_js( wp_create_nonce( 'pressable_cache_purge_nonce' ) ); ?>',
 					};
 
 		jQuery.post(ajaxurl, data, function(response) {
@@ -63,13 +64,17 @@ add_action( 'wp_ajax_pressable_cache_purge', 'pressable_cache_purge_callback' );
 
 
 function pressable_cache_purge_callback() {
+	check_ajax_referer( 'pressable_cache_purge_nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'message' => 'Unauthorized' ), 403 );
+	}
+
 	wp_cache_flush();
 
 	//Save time stamp to database if cache is flushed.
-	$object_cache_flush_time = date( ' jS F Y  g:ia' ) . "\nUTC";
+	$object_cache_flush_time = gmdate( 'j M Y, g:ia' ) . ' UTC';
 
 	update_option( 'flush-obj-cache-time-stamp', $object_cache_flush_time );
-	$response = 'Object Cache Purged';
-	echo $response;
-	wp_die();
+	wp_send_json_success( array( 'message' => 'Object Cache Purged' ) );
 }

--- a/admin/custom-functions/cache-wpp-cookie-page.php
+++ b/admin/custom-functions/cache-wpp-cookie-page.php
@@ -61,7 +61,7 @@ if (isset($options['cache_wpp_cookies_pages']) && !empty($options['cache_wpp_coo
 
         if (!empty($message))
         {
-            printf('<div class="notice %2$s">%1$s</div>', $message, $classes);
+            printf('<div class="notice %2$s">%1$s</div>', wp_kses_post( $message ), esc_attr( $classes ));
         }
     }
 

--- a/admin/custom-functions/defensive-mode-edge-cache.php
+++ b/admin/custom-functions/defensive-mode-edge-cache.php
@@ -92,8 +92,8 @@ function pcm_pressable_enable_defensive_mode() {
         ),
     ) );
 
-    if ( false === $result['success'] ) {
-        $err = ! empty( $result['error'] ) ? $result['error'] : esc_html__( 'Unknown error enabling Defensive Mode.', 'pressable_cache_management' );
+    if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+        $err = ( is_array( $result ) && ! empty( $result['error'] ) ) ? $result['error'] : esc_html__( 'Unknown error enabling Defensive Mode.', 'pressable_cache_management' );
         add_action( 'admin_notices', function() use ( $err ) {
             if ( function_exists( 'pcm_branded_notice' ) ) {
                 pcm_branded_notice( $err, '#dd3a03' );
@@ -149,8 +149,8 @@ function pcm_pressable_disable_defensive_mode() {
         ),
     ) );
 
-    if ( false === $result['success'] ) {
-        $err = ! empty( $result['error'] ) ? $result['error'] : esc_html__( 'Unknown error disabling Defensive Mode.', 'pressable_cache_management' );
+    if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+        $err = ( is_array( $result ) && ! empty( $result['error'] ) ) ? $result['error'] : esc_html__( 'Unknown error disabling Defensive Mode.', 'pressable_cache_management' );
         add_action( 'admin_notices', function() use ( $err ) {
             if ( function_exists( 'pcm_branded_notice' ) ) {
                 pcm_branded_notice( $err, '#dd3a03' );
@@ -177,6 +177,8 @@ add_action( 'init', 'pcm_pressable_disable_defensive_mode' );
 // Uses get_ec_ddos_until() which calls query_ec_backend( 'ddos_until' ) as a
 // GET (no body args) and returns the ddos_until Unix timestamp, or 0 if off.
 function pcm_ajax_check_defensive_mode_status() {
+    check_ajax_referer( 'pcm_defensive_mode_status_nonce' );
+
     if ( ! current_user_can( 'manage_options' ) ) {
         wp_send_json_error( [ 'message' => 'Unauthorized' ], 403 );
         return;

--- a/admin/custom-functions/exclude-query-string-gclid-from-cache.php
+++ b/admin/custom-functions/exclude-query-string-gclid-from-cache.php
@@ -63,7 +63,7 @@ if (isset($options['exclude_query_string_gclid_checkbox']) && !empty($options['e
 
         if (!empty($message))
         {
-            printf('<div class="notice %2$s">%1$s</div>', $message, $classes);
+            printf('<div class="notice %2$s">%1$s</div>', wp_kses_post( $message ), esc_attr( $classes ));
         }
     }
 

--- a/admin/custom-functions/flush-batcache-for-particular-page.php
+++ b/admin/custom-functions/flush-batcache-for-particular-page.php
@@ -14,7 +14,7 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
     add_action( 'init', 'pcm_show_flush_cache_column' );
 
     function pcm_show_flush_cache_column() {
-        if ( current_user_can('administrator') || current_user_can('editor') || current_user_can('manage_woocommerce') ) {
+        if ( current_user_can('manage_options') || current_user_can('edit_posts') || current_user_can('manage_woocommerce') ) {
             $column = new FlushObjectCachePageColumn();
             $column->add();
         }
@@ -24,7 +24,7 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
         $state = get_option( 'flush-object-cache-for-single-page-notice', 'activating' );
 
         if ( 'activating' === $state &&
-            ( current_user_can('administrator') || current_user_can('editor') || current_user_can('manage_woocommerce') )
+            ( current_user_can('manage_options') || current_user_can('edit_posts') || current_user_can('manage_woocommerce') )
         ) {
             add_action( 'admin_notices', function() {
                 $screen = get_current_screen();
@@ -68,7 +68,7 @@ if ( ! class_exists( 'FlushObjectCachePageColumn' ) ) {
         }
 
         public function add_flush_object_cache_link( $actions, $post ) {
-            if ( current_user_can('administrator') || current_user_can('editor') || current_user_can('manage_woocommerce') ) {
+            if ( current_user_can('manage_options') || current_user_can('edit_posts') || current_user_can('manage_woocommerce') ) {
                 $actions['flush_object_cache_url'] =
                     '<a data-id="' . esc_attr( $post->ID ) . '"'
                     . ' data-nonce="' . wp_create_nonce( 'flush-object-cache_' . $post->ID ) . '"'
@@ -80,28 +80,28 @@ if ( ! class_exists( 'FlushObjectCachePageColumn' ) ) {
         }
 
         public function flush_object_cache_column() {
-            if ( ! ( current_user_can('administrator') || current_user_can('editor') || current_user_can('manage_woocommerce') ) ) {
-                die( json_encode( array( 'success' => false, 'message' => 'Unauthorized' ) ) );
+            if ( ! ( current_user_can('manage_options') || current_user_can('edit_posts') || current_user_can('manage_woocommerce') ) ) {
+                wp_send_json_error( array( 'message' => 'Unauthorized' ), 403 );
             }
 
-            if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'flush-object-cache_' . intval( $_GET['id'] ) ) ) {
-                die( json_encode( array( 'success' => false, 'message' => 'Nonce verification failed' ) ) );
+            if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'flush-object-cache_' . intval( $_POST['id'] ) ) ) {
+                wp_send_json_error( array( 'message' => 'Nonce verification failed' ), 403 );
             }
 
-            $url_key    = get_permalink( intval( $_GET['id'] ) );
-            $page_title = get_the_title( intval( $_GET['id'] ) );
+            $url_key    = get_permalink( intval( $_POST['id'] ) );
+            $page_title = get_the_title( intval( $_POST['id'] ) );
             update_option( 'page-title', $page_title );
 
             global $batcache, $wp_object_cache;
 
             if ( ! isset( $batcache ) || ! is_object( $batcache ) || ! method_exists( $wp_object_cache, 'incr' ) ) {
-                die( json_encode( array( 'success' => false ) ) );
+                wp_send_json_error( array( 'message' => 'Batcache not available' ) );
             }
 
             $batcache->configure_groups();
             $url = apply_filters( 'batcache_manager_link', $url_key );
             if ( empty( $url ) ) {
-                die( json_encode( array( 'success' => false ) ) );
+                wp_send_json_error( array( 'message' => 'Empty URL' ) );
             }
 
             do_action( 'batcache_manager_before_flush', $url );
@@ -111,11 +111,12 @@ if ( ! class_exists( 'FlushObjectCachePageColumn' ) ) {
             wp_cache_add( "{$url_key}_version", 0, $batcache->group );
             wp_cache_incr( "{$url_key}_version", 1, $batcache->group );
 
+            $retval = wp_cache_get( "{$url_key}_version", $batcache->group );
             if ( property_exists( $wp_object_cache, 'no_remote_groups' ) ) {
                 $k = array_search( $batcache->group, (array) $wp_object_cache->no_remote_groups );
                 if ( false !== $k ) {
                     unset( $wp_object_cache->no_remote_groups[ $k ] );
-                    wp_cache_set( "{$url_key}_version", $batcache->group );
+                    wp_cache_set( "{$url_key}_version", $retval, $batcache->group );
                     $wp_object_cache->no_remote_groups[ $k ] = $batcache->group;
                 }
             }
@@ -125,14 +126,15 @@ if ( ! class_exists( 'FlushObjectCachePageColumn' ) ) {
             // Also store the flushed URL so it shows on the settings page
             update_option( 'single-page-url-flushed', $url );
 
-            die( json_encode( array( 'success' => true ) ) );
+            wp_send_json_success( array( 'message' => 'Cache flushed' ) );
         }
 
         public function load_js() {
+            $js_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/js/column.js';
             wp_enqueue_script(
                 'flush-object-cache-column',
                 plugin_dir_url( dirname( __FILE__ ) ) . 'public/js/column.js',
-                array(), time(), true
+                array(), file_exists( $js_file ) ? filemtime( $js_file ) : '1.0', true
             );
         }
     }

--- a/admin/custom-functions/flush-batcache-for-woo-individual-page.php
+++ b/admin/custom-functions/flush-batcache-for-woo-individual-page.php
@@ -28,7 +28,7 @@ if ( $enabled ) {
     $needs_update = ! file_exists( $mu_plugin_dest )
         || ( file_exists( $mu_plugin_src ) && md5_file( $mu_plugin_src ) !== md5_file( $mu_plugin_dest ) );
 
-    if ( $needs_update && file_exists( $mu_plugin_src ) && @copy( $mu_plugin_src, $mu_plugin_dest ) ) {
+    if ( $needs_update && file_exists( $mu_plugin_src ) && copy( $mu_plugin_src, $mu_plugin_dest ) ) {
         if ( ! file_exists( $mu_plugin_dest ) ) {
             // Only flush and show notice on fresh enable, not on every update
             wp_cache_flush();
@@ -93,7 +93,7 @@ if ( $enabled ) {
     update_option( 'flush_batcache_for_woo_product_individual_page_activate_notice', 'activating' );
 
     if ( file_exists( $mu_plugin_dest ) ) {
-        @unlink( $mu_plugin_dest );
+        unlink( $mu_plugin_dest );
         wp_cache_flush();
     }
 

--- a/admin/custom-functions/flush-cache-on-comment-delete.php
+++ b/admin/custom-functions/flush-cache-on-comment-delete.php
@@ -1,5 +1,9 @@
 <?php // Pressable Cache Management  - Flush cache when comment is deleted
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 $options = get_option('pressable_cache_management_options');
 
 
@@ -21,7 +25,7 @@ function pcm_trash_comment_action( $comment_id, $comment ){
 	 wp_cache_flush();
 	
 		//Save time stamp to database if cache is flushed when comment is deleted.
-        $object_cache_flush_time = date(' jS F Y  g:ia') . "\nUTC";
+        $object_cache_flush_time = gmdate( 'j M Y, g:ia' ) . ' UTC';
         update_option('flush-cache-on-comment-delete-time-stamp', $object_cache_flush_time);
    }
 	

--- a/admin/custom-functions/flush-cache-on-page-edit.php
+++ b/admin/custom-functions/flush-cache-on-page-edit.php
@@ -67,11 +67,12 @@ if ( isset( $options['flush_cache_page_edit_checkbox'] ) && ! empty( $options['f
         wp_cache_incr( "{$url_key}_version", 1, $batcache->group );
 
         // Handle sites where the Batcache group is excluded from remote sync
+        $retval = wp_cache_get( "{$url_key}_version", $batcache->group );
         if ( property_exists( $wp_object_cache, 'no_remote_groups' ) ) {
             $k = array_search( $batcache->group, (array) $wp_object_cache->no_remote_groups );
             if ( false !== $k ) {
                 unset( $wp_object_cache->no_remote_groups[ $k ] );
-                wp_cache_set( "{$url_key}_version", $batcache->group );
+                wp_cache_set( "{$url_key}_version", $retval, $batcache->group );
                 $wp_object_cache->no_remote_groups[ $k ] = $batcache->group;
             }
         }

--- a/admin/custom-functions/flush-cache-on-page-post-delete.php
+++ b/admin/custom-functions/flush-cache-on-page-post-delete.php
@@ -25,8 +25,8 @@ if (isset($options['flush_cache_on_page_post_delete_checkbox']) && !empty($optio
         wp_cache_flush();
    }
 
-       // Save time stamp to database if cache is flushed when a post or page was daleted.
-        $object_cache_flush_time = date(' jS F Y  g:ia') . "\nUTC";
+       // Save time stamp to database if cache is flushed when a post or page was deleted.
+        $object_cache_flush_time = gmdate( 'j M Y, g:ia' ) . ' UTC';
         update_option('flush-cache-on-page-post-delete-time-stamp', $object_cache_flush_time);
 
         //Set transient for admin notice for 9 seconds

--- a/admin/custom-functions/flush-single-page-toolbar.php
+++ b/admin/custom-functions/flush-single-page-toolbar.php
@@ -41,8 +41,8 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
             }
 
             public function pcm_delete_current_page_cache() {
-                if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'pcm_nonce' ) ) {
-                    die( json_encode( array( 'Security Error!', 'error', 'alert' ) ) );
+                if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'pcm_nonce' ) ) {
+                    wp_send_json_error( array( 'message' => 'Security Error!' ), 403 );
                 }
 
                 global $batcache, $wp_object_cache;
@@ -52,15 +52,15 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
                 }
 
                 $batcache->configure_groups();
-                $path = urldecode( esc_url_raw( wp_unslash( $_GET['path'] ) ) );
+                $path = urldecode( esc_url_raw( wp_unslash( $_POST['path'] ) ) );
 
                 if ( preg_match( '/\.{2,}/', $path ) ) {
-                    die( 'Suspected Directory Traversal Attack' );
+                    wp_send_json_error( array( 'message' => 'Suspected Directory Traversal Attack' ), 400 );
                 }
 
                 $url = get_home_url() . $path;
                 $url = apply_filters( 'batcache_manager_link', $url );
-                if ( empty( $url ) ) return false;
+                if ( empty( $url ) ) wp_send_json_error( array( 'message' => 'Empty URL' ) );
 
                 do_action( 'batcache_manager_before_flush', $url );
                 $url = set_url_scheme( $url, 'http' );
@@ -72,11 +72,12 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
                     wp_cache_incr( "{$url_key}_version", 1, $batcache->group );
                 }
 
+                $retval = wp_cache_get( "{$url_key}_version", $batcache->group );
                 if ( property_exists( $wp_object_cache, 'no_remote_groups' ) ) {
                     $k = array_search( $batcache->group, (array) $wp_object_cache->no_remote_groups );
                     if ( false !== $k ) {
                         unset( $wp_object_cache->no_remote_groups[ $k ] );
-                        wp_cache_set( "{$url_key}_version", $batcache->group );
+                        wp_cache_set( "{$url_key}_version", $retval, $batcache->group );
                         $wp_object_cache->no_remote_groups[ $k ] = $batcache->group;
                     }
                 }
@@ -87,13 +88,13 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
             }
 
             public function pcm_purge_current_page_edge_cache() {
-                if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'pcm_nonce' ) ) {
-                    die( json_encode( array( 'Security Error!', 'error', 'alert' ) ) );
+                if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'pcm_nonce' ) ) {
+                    wp_send_json_error( array( 'message' => 'Security Error!' ), 403 );
                 }
 
-                $path = urldecode( esc_url_raw( wp_unslash( $_GET['path'] ) ) );
+                $path = urldecode( esc_url_raw( wp_unslash( $_POST['path'] ) ) );
                 if ( preg_match( '/\.{2,}/', $path ) ) {
-                    die( 'Suspected Directory Traversal Attack' );
+                    wp_send_json_error( array( 'message' => 'Suspected Directory Traversal Attack' ), 400 );
                 }
 
                 $url = get_home_url() . $path;
@@ -111,15 +112,17 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
             }
 
             public function load_toolbar_css() {
+                $css_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/css/toolbar.css';
                 wp_enqueue_style( 'pressable-cache-management-toolbar',
                     plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/toolbar.css',
-                    array(), time(), 'all' );
+                    array(), file_exists( $css_file ) ? filemtime( $css_file ) : '1.0', 'all' );
             }
 
             public function load_toolbar_js() {
+                $js_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/js/toolbar.js';
                 wp_enqueue_script( 'pcm-toolbar',
                     plugin_dir_url( dirname( __FILE__ ) ) . 'public/js/toolbar.js',
-                    array( 'jquery' ), time(), true );
+                    array( 'jquery' ), file_exists( $js_file ) ? filemtime( $js_file ) : '1.0', true );
 
                 // Pass nonce and edge-cache state to JS for BOTH admin and frontend contexts.
                 // pcm_nonce from print_my_inline_script() only runs on wp_footer (frontend).
@@ -133,9 +136,10 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
             }
 
             public function load_remove_branding_toolbar_js() {
+                $js_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/js/toolbar_remove_branding.js';
                 wp_enqueue_script( 'pcm-toolbar-branding',
                     plugin_dir_url( dirname( __FILE__ ) ) . 'public/js/toolbar_remove_branding.js',
-                    array( 'jquery' ), time(), true );
+                    array( 'jquery' ), file_exists( $js_file ) ? filemtime( $js_file ) : '1.0', true );
             }
 
             public function print_my_inline_script() { ?>
@@ -150,7 +154,7 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
                 global $wp_admin_bar;
 
                 $branding_opts     = get_option( 'remove_pressable_branding_tab_options' );
-                $branding_disabled = $branding_opts && 'disable' == $branding_opts['branding_on_off_radio_button'];
+                $branding_disabled = is_array( $branding_opts ) && isset( $branding_opts['branding_on_off_radio_button'] ) && 'disable' === $branding_opts['branding_on_off_radio_button'];
                 $edge_cache_on     = ( get_option('edge-cache-enabled') === 'enabled' );
 
                 // Single label: include Edge Cache in the title when it is active
@@ -197,15 +201,16 @@ if ( isset( $options['flush_object_cache_for_single_page'] ) && ! empty( $option
 
     function pcm_show_flush_cache_option_for_single_page() {
         $current_user = wp_get_current_user();
-        if ( current_user_can('manage_woocommerce') || current_user_can('administrator') ) {
+        if ( current_user_can('manage_options') || current_user_can('manage_woocommerce') ) {
             $toolbar = new PcmFlushCacheAdminbar();
             $toolbar->add();
         } else {
             if ( ! function_exists('load_admin_toolbar_css') ) {
                 function load_admin_toolbar_css() {
+                    $css_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/css/toolbar.css';
                     wp_enqueue_style( 'pressable-cache-management-toolbar',
                         plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/toolbar.css',
-                        array(), time(), 'all' );
+                        array(), file_exists( $css_file ) ? filemtime( $css_file ) : '1.0', 'all' );
                 }
             }
             add_action( 'init', 'load_admin_toolbar_css' );

--- a/admin/custom-functions/object-cache-admin-bar.php
+++ b/admin/custom-functions/object-cache-admin-bar.php
@@ -41,12 +41,15 @@ function pcm_abar_modal_html() {
 
 // ─── JS: Flush Object Cache ────────────────────────────────────────────────
 add_action( 'admin_footer', 'pcm_abar_object_js' );
-function pcm_abar_object_js() { ?>
+function pcm_abar_object_js() {
+    if ( ! pcm_abar_can_view() ) return;
+    $nonce = wp_create_nonce( 'pcm_abar_nonce' );
+    ?>
     <script>
     jQuery(document).ready(function($){
         $('li#wp-admin-bar-cache-purge .ab-item').on('click', function(e){
             e.preventDefault();
-            $.post(ajaxurl, { action: 'flush_pressable_cache' }, function(r){
+            $.post(ajaxurl, { action: 'flush_pressable_cache', _ajax_nonce: '<?php echo esc_js( $nonce ); ?>' }, function(r){
                 window.pcmShowModal(r.trim());
             });
         });
@@ -56,12 +59,15 @@ function pcm_abar_object_js() { ?>
 
 // ─── JS: Purge Edge Cache ──────────────────────────────────────────────────
 add_action( 'admin_footer', 'pcm_abar_edge_js' );
-function pcm_abar_edge_js() { ?>
+function pcm_abar_edge_js() {
+    if ( ! pcm_abar_can_view() ) return;
+    $nonce = wp_create_nonce( 'pcm_abar_nonce' );
+    ?>
     <script>
     jQuery(document).ready(function($){
         $('li#wp-admin-bar-edge-purge .ab-item').on('click', function(e){
             e.preventDefault();
-            $.ajax({ url: ajaxurl, type: 'POST', data: { action: 'pressable_edge_cache_purge' },
+            $.ajax({ url: ajaxurl, type: 'POST', data: { action: 'pressable_edge_cache_purge', _ajax_nonce: '<?php echo esc_js( $nonce ); ?>' },
                 success: function(r){ window.pcmShowModal(r.trim()); },
                 error:   function(){ window.pcmShowModal('An error occurred during the Edge Cache purge request.'); }
             });
@@ -72,12 +78,15 @@ function pcm_abar_edge_js() { ?>
 
 // ─── JS: Flush Object + Edge Cache ────────────────────────────────────────
 add_action( 'admin_footer', 'pcm_abar_combined_js' );
-function pcm_abar_combined_js() { ?>
+function pcm_abar_combined_js() {
+    if ( ! pcm_abar_can_view() ) return;
+    $nonce = wp_create_nonce( 'pcm_abar_nonce' );
+    ?>
     <script>
     jQuery(document).ready(function($){
         $('li#wp-admin-bar-combined-cache-purge .ab-item').on('click', function(e){
             e.preventDefault();
-            $.ajax({ url: ajaxurl, type: 'POST', data: { action: 'flush_combined_cache' },
+            $.ajax({ url: ajaxurl, type: 'POST', data: { action: 'flush_combined_cache', _ajax_nonce: '<?php echo esc_js( $nonce ); ?>' },
                 success: function(r){ window.pcmShowModal(r.trim()); },
                 error:   function(){ window.pcmShowModal('An error occurred during the combined cache flush.'); }
             });
@@ -88,9 +97,10 @@ function pcm_abar_combined_js() { ?>
 
 // ─── Enqueue toolbar CSS ───────────────────────────────────────────────────
 function pcm_abar_load_css() {
+    $css_file = plugin_dir_path( dirname( __FILE__ ) ) . 'public/css/toolbar.css';
     wp_enqueue_style( 'pressable-cache-management-toolbar',
         plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/toolbar.css',
-        array(), time(), 'all' );
+        array(), file_exists( $css_file ) ? filemtime( $css_file ) : '1.0', 'all' );
 }
 add_action( 'init', 'pcm_abar_load_css' );
 
@@ -100,9 +110,10 @@ add_action( 'wp_ajax_pressable_edge_cache_purge', 'pcm_abar_purge_edge_callback'
 add_action( 'wp_ajax_flush_combined_cache',     'pcm_abar_flush_combined_callback' );
 
 function pcm_abar_flush_object_callback() {
-    if ( ! current_user_can('administrator') && ! current_user_can('editor') && ! current_user_can('manage_woocommerce') ) {
-        echo 'You do not have permission to flush the Object Cache.';
-        wp_die();
+    check_ajax_referer( 'pcm_abar_nonce' );
+
+    if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( array( 'message' => 'You do not have permission to flush the Object Cache.' ), 403 );
     }
     wp_cache_flush();
     if ( function_exists('batcache_clear_cache') ) batcache_clear_cache();
@@ -112,9 +123,10 @@ function pcm_abar_flush_object_callback() {
 }
 
 function pcm_abar_purge_edge_callback() {
-    if ( ! current_user_can('administrator') && ! current_user_can('editor') && ! current_user_can('manage_woocommerce') ) {
-        echo 'You do not have permission to purge the Edge Cache.';
-        wp_die();
+    check_ajax_referer( 'pcm_abar_nonce' );
+
+    if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( array( 'message' => 'You do not have permission to purge the Edge Cache.' ), 403 );
     }
     if ( ! class_exists('Edge_Cache_Plugin') ) {
         echo esc_html__( 'Error: Edge Cache Plugin is not active. Purge aborted.', 'pressable_cache_management' );
@@ -136,9 +148,10 @@ function pcm_abar_purge_edge_callback() {
 }
 
 function pcm_abar_flush_combined_callback() {
-    if ( ! current_user_can('administrator') && ! current_user_can('editor') && ! current_user_can('manage_woocommerce') ) {
-        echo 'You do not have permission to flush the combined cache.';
-        wp_die();
+    check_ajax_referer( 'pcm_abar_nonce' );
+
+    if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( array( 'message' => 'You do not have permission to flush the combined cache.' ), 403 );
     }
     $messages = array();
 
@@ -173,7 +186,7 @@ function pcm_abar_flush_combined_callback() {
 // ─── Permission check ─────────────────────────────────────────────────────
 if ( ! function_exists('pcm_abar_can_view') ) {
     function pcm_abar_can_view() {
-        return current_user_can('administrator') || current_user_can('editor') || current_user_can('manage_woocommerce');
+        return current_user_can('manage_options') || current_user_can('manage_woocommerce');
     }
 }
 
@@ -183,7 +196,7 @@ function pcm_abar_add_menu( $wp_admin_bar ) {
     if ( is_network_admin() || ! pcm_abar_can_view() ) return;
 
     $branding_opts     = get_option('remove_pressable_branding_tab_options');
-    $branding_disabled = $branding_opts && 'disable' == $branding_opts['branding_on_off_radio_button'];
+    $branding_disabled = is_array( $branding_opts ) && isset( $branding_opts['branding_on_off_radio_button'] ) && 'disable' === $branding_opts['branding_on_off_radio_button'];
 
     $parent_id    = $branding_disabled ? 'pcm-wp-admin-toolbar-parent-remove-branding' : 'pcm-wp-admin-toolbar-parent';
     $parent_title = $branding_disabled ? 'Cache Control' : 'Cache Management';
@@ -228,7 +241,7 @@ function pcm_abar_add_menu( $wp_admin_bar ) {
     }
 
     // Cache Settings (admin only)
-    if ( current_user_can('administrator') ) {
+    if ( current_user_can('manage_options') ) {
         $wp_admin_bar->add_menu( array(
             'id'     => 'settings',
             'title'  => __( 'Cache Settings', 'pressable_cache_management' ),

--- a/admin/custom-functions/pcm-batcache-manager.php
+++ b/admin/custom-functions/pcm-batcache-manager.php
@@ -8,6 +8,10 @@
  * Version: 2.0.2
 */
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 /**
  * Class Batcache_Manager
  */
@@ -177,22 +181,14 @@ class Batcache_Manager {
 
             // 3. Purge Edge Cache for the specific URL
             if (class_exists('Edge_Cache_Plugin')) {
-                // Set the default timezone to UTC before calling date()
-                $timezone_backup = date_default_timezone_get();
-                date_default_timezone_set('UTC');
-
                 $edge_cache = Edge_Cache_Plugin::get_instance();
                 $urls = array($product_url);
-                
+
                 // Use the correct method to purge URIs
                 $result = $edge_cache->purge_uris_now($urls);
-                    
-                // Save time stamp to database if edge cache is purged for particular page
-                $edge_cache_purge_time = date('jS F Y g:ia') . "\nUTC";
-                update_option('single-page-edge-cache-purge-time-stamp', $edge_cache_purge_time);
 
-                // Restore the original timezone
-                date_default_timezone_set($timezone_backup);
+                // Save time stamp to database if edge cache is purged for particular page
+                update_option('single-page-edge-cache-purge-time-stamp', gmdate( 'j M Y, g:ia' ) . ' UTC');
             }
         }
 
@@ -411,20 +407,8 @@ class Batcache_Manager {
         // Clear out links
         $this->links = array();
 
-        // --- START OF MODIFIED CODE ---
-
-        // Set the default timezone to UTC before calling date()
-        $timezone_backup = date_default_timezone_get();
-        date_default_timezone_set('UTC');
-
         // Update the timestamp option with the specified format
-        $batcache_flush_time = date('jS F Y g:ia') . "\nUTC";
-        update_option( 'flush-object-cache-for-single-page-time-stamp', $batcache_flush_time );
-
-        // Restore the original timezone
-        date_default_timezone_set($timezone_backup);
-
-        // --- END OF MODIFIED CODE ---
+        update_option( 'flush-object-cache-for-single-page-time-stamp', gmdate( 'j M Y, g:ia' ) . ' UTC' );
     }
 
     /**

--- a/admin/custom-functions/purge-edge-cache.php
+++ b/admin/custom-functions/purge-edge-cache.php
@@ -48,7 +48,6 @@ if ( isset( $_POST['purge_edge_cache_nonce'] ) ) {
                     $enabled = $edge_cache->$enable_method();
                     if ( $enabled ) {
                         $auto_enabled = true;
-                        sleep( 2 );
                     } else {
                         add_action( 'admin_notices', function() {
                             if ( function_exists( 'pcm_branded_notice' ) ) {

--- a/admin/custom-functions/remove-pressable-branding.php
+++ b/admin/custom-functions/remove-pressable-branding.php
@@ -1,63 +1,22 @@
 <?php //Pressable Cache Management - Custom function to turn on/off Pressable branding
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 /******************************
  * Show branding Option
  *******************************/
 
-$pressable_branding = false;
+$hide_pressable_branding_tab_options = get_option( 'remove_pressable_branding_tab_options' );
 
-$hide_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
-
-//Check if options are set before processing
-if (isset($hide_pressable_branding_tab_options['branding_on_off_radio_button']) && !empty($hide_pressable_branding_tab_options['branding_on_off_radio_button']))
-{
-
-    $hide_pressable_branding_tab_options = sanitize_text_field($hide_pressable_branding_tab_options['branding_on_off_radio_button']);
-
+// Safely extract the branding radio value
+$branding_state = '';
+if ( is_array( $hide_pressable_branding_tab_options ) && isset( $hide_pressable_branding_tab_options['branding_on_off_radio_button'] ) ) {
+    $branding_state = sanitize_text_field( $hide_pressable_branding_tab_options['branding_on_off_radio_button'] );
 }
 
-//Set radion button state to defualt
-if ('enable' === $hide_pressable_branding_tab_options)
-{
-
-    $hide_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
-
-    // echo 'Show Branding';
-    //run your functions here if radio button is enabled
-    
-}
-
-/******************************
- * Hide branding Option
- *******************************/
-
-else
-{
-
-    $pressable_branding = false;
-
-    $pressable_branding = get_option('remove_pressable_branding_tab_options');
-
-    //Check if options are set before processing
-    if (isset($hide_pressable_branding_tab_options['branding_on_off_radio_button']) && !empty($hide_pressable_branding_tab_options['branding_on_off_radio_button']))
-    {
-
-        $hide_pressable_branding_tab_options = sanitize_text_field($hide_pressable_branding_tab_options['branding_on_off_radio_button']);
-
-    }
-
-    //Set radio button state to defualt
-    if ('disable' === $hide_pressable_branding_tab_options)
-    {
-
-        $hide_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
-
-        // echo 'Hide Branding';
-        //run your functions here if radio button is disbaled      
-
-        
-    }
-
-}
+// 'enable' = show branding (default), 'disable' = hide branding
+// Currently no runtime logic is needed for either state — the value is consumed
+// by admin-menu.php, settings-register.php, and other files via get_option().
 

--- a/admin/custom-functions/turn-on-off-edge-cache.php
+++ b/admin/custom-functions/turn-on-off-edge-cache.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'pcm_branded_notice' ) ) {
         echo '<div id="' . esc_attr( $id ) . '" style="' . $wrap . '">';
         echo '<div style="flex:1;">';
         if ( $is_html ) {
-            echo $message; // caller already escaped
+            echo wp_kses_post( $message );
         } else {
             echo '<p style="margin:0;font-size:13px;color:#040024;">' . esc_html( $message ) . '</p>';
         }
@@ -90,6 +90,10 @@ function pcm_pressable_enable_edge_cache() {
     if ( isset( $_POST['enable_edge_cache_nonce'] ) &&
          wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['enable_edge_cache_nonce'] ) ), 'enable_edge_cache_nonce' ) ) {
 
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
         if ( class_exists( 'Edge_Cache_Plugin' ) ) {
             $edge_cache = Edge_Cache_Plugin::get_instance();
             $result = $edge_cache->query_ec_backend( 'on', array( 'wp_action' => 'manual_dashboard_set' ) );
@@ -119,6 +123,10 @@ add_action( 'init', 'pcm_pressable_enable_edge_cache' );
 function pcm_pressable_disable_edge_cache() {
     if ( isset( $_POST['disable_edge_cache_nonce'] ) &&
          wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['disable_edge_cache_nonce'] ) ), 'disable_edge_cache_nonce' ) ) {
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
 
         if ( class_exists( 'Edge_Cache_Plugin' ) ) {
             $edge_cache = Edge_Cache_Plugin::get_instance();

--- a/admin/custom-functions/wp-write-to-file-lib.php
+++ b/admin/custom-functions/wp-write-to-file-lib.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 function pressable_cache_extend()
 {
 
@@ -17,16 +21,16 @@ function is_writeable_wp_config($path)
     // PHP's is_writable does not work with Win32 NTFS
     if ($path[strlen($path) - 1] == '/')
     { // recursively return a temporary file path
-        return is_writeable_wp_config($path . uniqid(mt_rand()) . '.tmp');
+        return is_writeable_wp_config($path . wp_unique_filename( $path, 'wpsc_test.tmp' ));
     }
     elseif (is_dir($path))
     {
-        return is_writeable_wp_config($path . '/' . uniqid(mt_rand()) . '.tmp');
+        return is_writeable_wp_config($path . '/' . wp_unique_filename( $path, 'wpsc_test.tmp' ));
     }
 
     // check tmp file for read/write capabilities
     $rm = file_exists($path);
-    $f = @fopen($path, 'a');
+    $f = fopen($path, 'a');
     if ($f === false) return false;
     fclose($f);
     if (!$rm)
@@ -55,7 +59,7 @@ function is_writeable_wp_config($path)
 // }
 function wp_config_file_replace_line($old, $new, $my_file)
 {
-    if (@is_file($my_file) == false)
+    if (is_file($my_file) == false)
     {
         if (function_exists('set_transient'))
         {

--- a/admin/public/js/column.js
+++ b/admin/public/js/column.js
@@ -67,7 +67,7 @@ function flush_object_cache_column_button_action() {
             $('#flush-object-cache-url-' + post_id).css('cursor', 'wait');
 
             $.ajax({
-                type:     'GET',
+                type:     'POST',
                 url:      ajaxurl,
                 data:     { action: 'pcm_flush_object_cache_column', id: post_id, nonce: nonce },
                 dataType: 'json',

--- a/admin/public/js/toolbar.js
+++ b/admin/public/js/toolbar.js
@@ -37,10 +37,10 @@ jQuery(document).ready(function($) {
         'wp-admin-bar-pcm-toolbar-parent-remove-branding-flush-cache-of-this-page',
     ];
 
-    // ── Fire a single AJAX GET, returns a jQuery deferred ────────────────────
+    // ── Fire a single AJAX POST, returns a jQuery deferred ───────────────────
     function sendRequest( action ) {
         return $.ajax({
-            type    : 'GET',
+            type    : 'POST',
             url     : ajaxUrl,
             data    : { action: action, path: window.location.pathname, nonce: nonce },
             dataType: 'json',

--- a/admin/settings-callbacks.php
+++ b/admin/settings-callbacks.php
@@ -20,7 +20,7 @@ function pressable_cache_management_callback_section_cache()
 
     $remove_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
 
-    if ($remove_pressable_branding_tab_options && 'disable' == $remove_pressable_branding_tab_options['branding_on_off_radio_button'])
+    if ( is_array( $remove_pressable_branding_tab_options ) && isset( $remove_pressable_branding_tab_options['branding_on_off_radio_button'] ) && 'disable' === $remove_pressable_branding_tab_options['branding_on_off_radio_button'] )
     {
 
     }
@@ -126,7 +126,7 @@ function pressable_cache_management_callback_field_button($args)
     echo '<form method="post" id="flush_object_cache_nonce">
 
          <span id="flush_cache_button">
-        <input id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" type="submit" size="40" value="' . __('Flush Cache', 'pressable_cache_management') . '" class="flushcache"/><input type="hidden" name="flush_object_cache_nonce" value="' . wp_create_nonce('flush_object_cache_nonce') . '" <br/><label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . $label . '</label>
+        <input id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" type="submit" size="40" value="' . esc_attr__('Flush Cache', 'pressable_cache_management') . '" class="flushcache"/><input type="hidden" name="flush_object_cache_nonce" value="' . wp_create_nonce('flush_object_cache_nonce') . '" /><br/><label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>
          </span>
 
     </form>';
@@ -151,11 +151,11 @@ function pressable_cache_management_callback_field_extend_cache_checkbox($args)
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
 
 }
 
@@ -172,11 +172,11 @@ function pressable_cache_management_callback_field_plugin_theme_update_checkbox(
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
 
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
     echo '</br>';
     //Display time stamp when object cache was last flushed when theme plugin
@@ -197,11 +197,11 @@ function pressable_cache_management_callback_field_page_edit_checkbox($args)
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
     echo '</br>';
     //Display time stamp when object cache was last flushed when page or post was updated
@@ -223,11 +223,11 @@ function pressable_cache_management_callback_field_page_post_delete_checkbox($ar
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
     echo '</br>';
     //Display time stamp when object cache was last flushed when page or post was deleted
@@ -249,11 +249,11 @@ function pressable_cache_management_callback_field_comment_delete_checkbox($args
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
     echo '</br>';
     //Display time stamp when object cache was last flushed when comment was deleted
@@ -275,11 +275,11 @@ function pressable_cache_management_callback_field_flush_batcache_particular_pag
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
     echo '</br>';
     //Display time stamp when object cache was last flushed
@@ -305,11 +305,11 @@ function pressable_cache_management_callback_field_flush_batcache_woo_product_pa
 
     echo '<div class="container">';
     echo '<label class="switch">';
-    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" value="1"' . $checked . ' />';
+    echo '<input type="checkbox" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" value="1"' . $checked . ' />';
     echo '<span class="slider round"></span>
 </label>';
     // echo '</br>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
     echo '</br>';
 // 	echo '<small><strong>Last purged Edge at:</strong></small> ' . (get_option('single-page-edge-cache-purge-time-stamp')) . '<small></small>';
 //     echo '</br>';
@@ -324,8 +324,8 @@ function pressable_cache_management_callback_field_exempt_batcache_text($args)
     $id = isset($args['id']) ? $args['id'] : '';
     $label = isset($args['label']) ? $args['label'] : '';
     $value = isset($options[$id]) ? sanitize_text_field($options[$id]) : '';
-    echo '<input autocomplete="off" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . $id . ']" type="text" placeholder=" Exclude single page ex  /pagename/"  size="70" value="' . esc_attr( $value ) . '"><br/>';
-    echo '<label class="rad-text for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
+    echo '<input autocomplete="off" id="pressable_cache_management_options_' . esc_attr( $id ) . '" name="pressable_cache_management_options[' . esc_attr( $id ) . ']" type="text" placeholder=" Exclude single page ex  /pagename/"  size="70" value="' . esc_attr( $value ) . '"><br/>';
+    echo '<label class="rad-text" for="pressable_cache_management_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
 }
 /*
   
@@ -354,6 +354,8 @@ function pressable_cache_management_options_radio_edge_cache_button()
 // AJAX handler function to check Edge Cache status on demand
 function pcm_ajax_check_edge_cache_status()
 {
+    check_ajax_referer( 'pcm_edge_cache_status_nonce' );
+
     if (!current_user_can('manage_options')) {
         wp_send_json_error(['message' => 'Unauthorized'], 403);
         return;
@@ -365,7 +367,10 @@ function pcm_ajax_check_edge_cache_status()
     $cache_key = 'pcm_ec_status_cache';
     $cached    = get_transient( $cache_key );
 
-    if ( $cached !== false ) {
+    if (
+        is_array( $cached ) &&
+        isset( $cached['is_enabled'], $cached['status_text'], $cached['status_flag'] )
+    ) {
         // Serve from cache — no API call needed
         wp_send_json_success([
             'enabled'                    => $cached['is_enabled'],
@@ -375,6 +380,9 @@ function pcm_ajax_check_edge_cache_status()
             'html_controls_enable_disable' => pressable_cache_management_generate_enable_disable_content( $cached['is_enabled'] ),
         ]);
         return;
+    }
+    if ( false !== $cached ) {
+        delete_transient( $cache_key );
     }
 
     if ( ! class_exists('Edge_Cache_Plugin') ) {
@@ -542,7 +550,8 @@ function pressable_cache_management_callback_field_extend_edge_cache_radio_butto
                 url: ajaxurl,
                 type: 'POST',
                 data: {
-                    action: 'pcm_check_edge_cache_status'
+                    action: 'pcm_check_edge_cache_status',
+                    _ajax_nonce: '<?php echo esc_js( wp_create_nonce( "pcm_edge_cache_status_nonce" ) ); ?>'
                 },
                 success: function(response) {
                     if (response.success && response.data.html_controls_enable_disable) {
@@ -596,7 +605,7 @@ function pressable_edge_cache_flush_management_callback_field_button($args)
     echo '<form method="post" id="purge_edge_cache_nonce_form_static"> 
          <span id="purge_edge_cache_button_span_static">
               <input id="purge-edge-cache-button-input" 
-                     name="edge_cache_settings_tab_options[' . $id . ']" 
+                     name="edge_cache_settings_tab_options[' . esc_attr( $id ) . ']" 
                      type="submit" 
                      size="40" 
                      value="' . esc_attr__( 'Purge Edge Cache', 'pressable_cache_management' ) . '" 
@@ -662,9 +671,9 @@ function pressable_cache_management_callback_field_extend_remove_branding_radio_
         $checked = checked($selected_option === $value, true, false);
 
         echo '<label class="rad-label">';
-        echo '<input type="radio" class="rad-input" name="remove_pressable_branding_tab_options[' . $id . ']" type="radio" value="' . esc_attr( $value ) . '"' . $checked . ' name="rad">';
+        echo '<input type="radio" class="rad-input" name="remove_pressable_branding_tab_options[' . esc_attr( $id ) . ']" value="' . esc_attr( $value ) . '"' . $checked . '>';
         echo '<div class="rad-design"></div>';
-        echo '<span class="rad-text">' . esc_html( $label ) . '</span></label>';
+        echo '<span class="rad-text">' . esc_html( $label ) . '</span>';
         echo '</label>';
 
     }

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -81,7 +81,7 @@ if ( ! function_exists( 'pcm_branded_notice' ) ) {
               . 'line-height:1;padding:0;flex-shrink:0;margin-top:2px;';
         echo '<div id="' . esc_attr( $id ) . '" style="' . $wrap . '"><div style="flex:1;">';
         if ( $is_html ) {
-            echo $message;
+            echo wp_kses_post( $message );
         } else {
             echo '<p style="margin:0;font-size:13px;color:#040024;">' . esc_html( $message ) . '</p>';
         }
@@ -184,14 +184,17 @@ function pressable_cache_management_display_settings_page() {
     $tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : null;
 
     $branding_opts  = get_option('remove_pressable_branding_tab_options');
-    $show_branding  = ! ( $branding_opts && 'disable' == $branding_opts['branding_on_off_radio_button'] );
+    $show_branding  = ! (
+        is_array( $branding_opts ) &&
+        isset( $branding_opts['branding_on_off_radio_button'] ) &&
+        'disable' === $branding_opts['branding_on_off_radio_button']
+    );
 
     wp_enqueue_style( 'pressable_cache_management',
         plugin_dir_url( dirname( __FILE__ ) ) . 'public/css/style.css', array(), '3.0.0', 'screen' );
-    wp_enqueue_style( 'pcm-google-fonts',
-        'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap', array(), null );
+    // Google Fonts removed — using system font stack for privacy and performance.
     ?>
-    <div class="wrap" style="background:#f0f2f5;margin-left:-20px;margin-right:-20px;padding:24px 28px 40px;min-height:calc(100vh - 32px);font-family:'Inter',sans-serif;">
+    <div class="wrap" style="background:#f0f2f5;margin-left:-20px;margin-right:-20px;padding:24px 28px 40px;min-height:calc(100vh - 32px);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
     <div style="max-width:1120px;margin:0 auto;">
     <h1 style="display:none;"><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
@@ -225,13 +228,13 @@ function pressable_cache_management_display_settings_page() {
     <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:24px;flex-wrap:wrap;gap:12px;">
         <div>
             <?php if ( $show_branding ) : ?>
-            <p style="font-size:11px;font-weight:600;color:#94a3b8;letter-spacing:1.2px;text-transform:uppercase;margin:0 0 6px;font-family:'Inter',sans-serif;"><?php echo esc_html__( 'Cache Management by', 'pressable_cache_management' ); ?></p>
+            <p style="font-size:11px;font-weight:600;color:#94a3b8;letter-spacing:1.2px;text-transform:uppercase;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;"><?php echo esc_html__( 'Cache Management by', 'pressable_cache_management' ); ?></p>
             <img class="pressablecmlogo"
                  src="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'assets/img/pressable-logo-primary.svg' ); ?>"
                  alt="Pressable"
                  style="width:180px;height:auto;display:block;margin-bottom:6px;">
             <?php else : ?>
-            <h2 style="font-size:20px;font-weight:700;color:#040024;margin:0 0 6px;font-family:'Inter',sans-serif;"><?php echo esc_html__( 'Cache Control', 'pressable_cache_management' ); ?></h2>
+            <h2 style="font-size:20px;font-weight:700;color:#040024;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;"><?php echo esc_html__( 'Cache Control', 'pressable_cache_management' ); ?></h2>
             <?php endif; ?>
         </div>
         <div style="display:flex;align-items:center;gap:6px;">
@@ -243,8 +246,8 @@ function pressable_cache_management_display_settings_page() {
                         onclick="pcmRefreshBatcacheStatus()">&#x21BB;</button>
             </span>
             <span class="pcm-bc-tooltip-wrap" style="position:relative;display:inline-flex;align-items:center;">
-                <span style="width:16px;height:16px;border-radius:50%;background:#e2e8f0;color:#64748b;font-size:10px;font-weight:700;display:inline-flex;align-items:center;justify-content:center;cursor:default;font-family:'Inter',sans-serif;line-height:1;flex-shrink:0;" aria-label="Batcache info">&#x3F;</span>
-                <span class="pcm-bc-tooltip" style="display:none;position:absolute;right:0;top:24px;width:270px;background:#1e293b;color:#f1f5f9;font-size:11.5px;line-height:1.55;padding:10px 13px;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.18);z-index:9999;font-family:'Inter',sans-serif;font-weight:400;">
+                <span style="width:16px;height:16px;border-radius:50%;background:#e2e8f0;color:#64748b;font-size:10px;font-weight:700;display:inline-flex;align-items:center;justify-content:center;cursor:default;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;line-height:1;flex-shrink:0;" aria-label="Batcache info">&#x3F;</span>
+                <span class="pcm-bc-tooltip" style="display:none;position:absolute;right:0;top:24px;width:270px;background:#1e293b;color:#f1f5f9;font-size:11.5px;line-height:1.55;padding:10px 13px;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.18);z-index:9999;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;font-weight:400;">
                     <?php echo esc_html__( 'Use the refresh button to manually check your cache status. If the cache status remains broken for more than 4 minutes after two visits are recorded on your site, it is likely that caching is failing due to cookie interference from your plugin, theme or custom code.', 'pressable_cache_management' ); ?>
                     <span style="position:absolute;right:8px;top:-5px;width:0;height:0;border-left:5px solid transparent;border-right:5px solid transparent;border-bottom:5px solid #1e293b;"></span>
                 </span>
@@ -663,7 +666,7 @@ function pressable_cache_management_display_settings_page() {
     /* Edge Cache tab styles */
     .edge-cache-loader {
         display:flex;align-items:center;height:30px;
-        font-style:italic;color:#94a3b8;font-family:'Inter',sans-serif;font-size:13px;
+        font-style:italic;color:#94a3b8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;font-size:13px;
     }
     .edge-cache-loader::before {
         content:'';border:3px solid #e2e8f0;border-top:3px solid #03fcc2;
@@ -675,7 +678,7 @@ function pressable_cache_management_display_settings_page() {
     #edge-cache-control-wrapper input[type="submit"] {
         padding:10px 28px;border:none;border-radius:8px;
         font-size:14px;font-weight:700;cursor:pointer;
-        font-family:'Inter',sans-serif;transition:background .2s;
+        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;transition:background .2s;
     }
     /* Both Enable/Disable buttons use .purgecacahe → orange default, green hover */
     #edge_cache_settings_tab_options_enable,
@@ -704,7 +707,7 @@ function pressable_cache_management_display_settings_page() {
 
     <!-- Page heading -->
     <div style="margin-bottom:20px;">
-        <h2 style="font-size:20px;font-weight:700;color:#040024;margin:0 0 6px;font-family:'Inter',sans-serif;">
+        <h2 style="font-size:20px;font-weight:700;color:#040024;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
             <?php echo esc_html__( 'Manage Edge Cache Settings', 'pressable_cache_management' ); ?>
         </h2>
     </div>
@@ -716,10 +719,10 @@ function pressable_cache_management_display_settings_page() {
         <!-- Row 1: Turn On/Off -->
         <div style="display:flex;align-items:center;justify-content:space-between;gap:24px;padding:24px 28px;border-bottom:1px solid #f1f5f9;">
             <div>
-                <p style="font-size:15px;font-weight:700;color:#040024;margin:0 0 6px;font-family:'Inter',sans-serif;">
+                <p style="font-size:15px;font-weight:700;color:#040024;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                     <?php echo esc_html__( 'Turn On/Off Edge Cache', 'pressable_cache_management' ); ?>
                 </p>
-                <p style="font-size:13px;color:#64748b;margin:0;font-family:'Inter',sans-serif;">
+                <p style="font-size:13px;color:#64748b;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                     <?php echo esc_html__( 'Enable or disable the edge cache for this site.', 'pressable_cache_management' ); ?>
                 </p>
             </div>
@@ -733,7 +736,7 @@ function pressable_cache_management_display_settings_page() {
 
             <!-- Purge title + button -->
             <div style="display:flex;align-items:center;justify-content:space-between;gap:24px;margin-bottom:12px;">
-                <p style="font-size:15px;font-weight:700;color:#040024;margin:0;font-family:'Inter',sans-serif;">
+                <p style="font-size:15px;font-weight:700;color:#040024;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                     <?php echo esc_html__( 'Purge Edge Cache', 'pressable_cache_management' ); ?>
                 </p>
                 <form method="post" id="purge_edge_cache_nonce_form_static" style="flex-shrink:0;">
@@ -746,13 +749,13 @@ function pressable_cache_management_display_settings_page() {
                            disabled
                            class="ec-disabled-btn"
                            style="padding:10px 28px;border:none;border-radius:8px;font-size:14px;font-weight:700;
-                                  color:#fff;background:#dd3a03;font-family:'Inter',sans-serif;
+                                  color:#fff;background:#dd3a03;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
                                   transition:background .2s,opacity .2s;">
                 </form>
             </div>
 
             <!-- Description -->
-            <p style="font-size:13px;color:#64748b;margin:0 0 20px;font-family:'Inter',sans-serif;">
+            <p style="font-size:13px;color:#64748b;margin:0 0 20px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                 <?php echo esc_html__( 'Purging cache will temporarily slow down your site for all visitors while the cache rebuilds.', 'pressable_cache_management' ); ?>
             </p>
 
@@ -792,14 +795,14 @@ function pressable_cache_management_display_settings_page() {
             <!-- Title + status badge -->
             <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:24px;margin-bottom:10px;">
                 <div>
-                    <p style="font-size:15px;font-weight:700;color:#040024;margin:0 0 6px;font-family:'Inter',sans-serif;">
+                    <p style="font-size:15px;font-weight:700;color:#040024;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                         <?php echo esc_html__( 'Edge Cache Defensive Mode', 'pressable_cache_management' ); ?>
                     </p>
-                    <p style="font-size:13px;color:#64748b;margin:0 0 6px;font-family:'Inter',sans-serif;">
+                    <p style="font-size:13px;color:#64748b;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;">
                         <?php echo esc_html__( 'Adds an extra layer of protection against spam bots and DDoS attacks. When enabled, visitors\' browsers must complete a small challenge before accessing the site. Legitimate users may see a brief challenge page. Edge Cache must be enabled to use this feature.', 'pressable_cache_management' ); ?>
                     </p>
                     <!-- Live status line — populated by JS -->
-                    <div id="pcm-dm-status-line" style="font-size:13px;font-weight:600;color:#94a3b8;margin:6px 0 0;font-family:'Inter',sans-serif;font-style:italic;line-height:1.6;">
+                    <div id="pcm-dm-status-line" style="font-size:13px;font-weight:600;color:#94a3b8;margin:6px 0 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;font-style:italic;line-height:1.6;">
                         <?php echo esc_html__( 'Checking status…', 'pressable_cache_management' ); ?>
                     </div>
                 </div>
@@ -817,7 +820,7 @@ function pressable_cache_management_display_settings_page() {
                             name="defensive_mode_duration"
                             disabled
                             style="padding:9px 14px;border:1px solid #e2e8f0;border-radius:8px;
-                                   font-size:13px;font-family:'Inter',sans-serif;color:#040024;
+                                   font-size:13px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;color:#040024;
                                    background:#f8fafc;cursor:not-allowed;opacity:.5;transition:opacity .2s;">
                         <?php
                         $saved_slug = get_option( 'edge-cache-defensive-mode-slug', '30-minutes' );
@@ -833,7 +836,7 @@ function pressable_cache_management_display_settings_page() {
                            disabled
                            class="ec-disabled-btn"
                            style="padding:10px 22px;border:none;border-radius:8px;font-size:13px;font-weight:700;
-                                  color:#fff;background:#dd3a03;font-family:'Inter',sans-serif;
+                                  color:#fff;background:#dd3a03;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
                                   cursor:not-allowed;transition:background .2s,opacity .2s;">
                 </form>
 
@@ -847,7 +850,7 @@ function pressable_cache_management_display_settings_page() {
                            disabled
                            class="ec-disabled-btn"
                            style="padding:10px 22px;border:none;border-radius:8px;font-size:13px;font-weight:700;
-                                  color:#fff;background:#64748b;font-family:'Inter',sans-serif;
+                                  color:#fff;background:#64748b;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
                                   cursor:not-allowed;transition:background .2s,opacity .2s;">
                 </form>
 
@@ -876,7 +879,7 @@ function pressable_cache_management_display_settings_page() {
         function pcmApplyDmState( edgeCacheEnabled ) {
             $.ajax({
                 url: ajaxurl, type: 'POST',
-                data: { action: 'pcm_check_defensive_mode_status' },
+                data: { action: 'pcm_check_defensive_mode_status', _ajax_nonce: '<?php echo esc_js( wp_create_nonce( "pcm_defensive_mode_status_nonce" ) ); ?>' },
                 success: function(r) {
                     if ( ! r.success ) {
                         dmStatusLine
@@ -950,7 +953,7 @@ function pressable_cache_management_display_settings_page() {
             wrapper.data('ec-checked', true);
             $.ajax({
                 url: ajaxurl, type: 'POST',
-                data: { action: 'pcm_check_edge_cache_status' },
+                data: { action: 'pcm_check_edge_cache_status', _ajax_nonce: '<?php echo esc_js( wp_create_nonce( "pcm_edge_cache_status_nonce" ) ); ?>' },
                 success: function(r) {
                     var ecEnabled = false;
                     if (r.success && r.data.html_controls_enable_disable) {
@@ -1001,7 +1004,7 @@ function pressable_cache_management_display_settings_page() {
     }
     .pcm-card-title {
         font-size:15px;font-weight:700;color:#040024;margin:0 0 16px;
-        font-family:'Inter',sans-serif;
+        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
     }
     .pcm-toggle-row {
         display:flex;align-items:flex-start;gap:14px;
@@ -1009,22 +1012,22 @@ function pressable_cache_management_display_settings_page() {
     }
     .pcm-toggle-title {
         font-size:13.5px;font-weight:600;color:#040024;
-        font-family:'Inter',sans-serif;line-height:1.3;
+        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;line-height:1.3;
     }
     .pcm-toggle-desc {
-        font-size:12px;color:#64748b;margin-top:2px;font-family:'Inter',sans-serif;
+        font-size:12px;color:#64748b;margin-top:2px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
     }
     .pcm-ts-label {
         font-size:10px;color:#94a3b8;text-transform:uppercase;letter-spacing:.5px;
-        font-family:'Inter',sans-serif;font-weight:600;
+        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;font-weight:600;
     }
     .pcm-ts-value {
-        font-size:12.5px;color:#040024;font-family:'Inter',sans-serif;
+        font-size:12.5px;color:#040024;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
         font-weight:500;display:block;margin-top:2px;
     }
     .pcm-ts-inline {
         font-size:11.5px;color:#475569;display:block;margin-top:4px;
-        font-family:'Inter',sans-serif;font-weight:500;
+        font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;font-weight:500;
     }
     /* Flush button: red, hover green */
     #pcm-flush-btn,
@@ -1058,7 +1061,9 @@ function pcm_footer_msg() {
 function pcm_replace_default_footer($footer_text) {
     if ( is_admin() && isset($_GET['page']) && sanitize_key( $_GET['page'] ) === 'pressable_cache_management' ) {
         $opts              = get_option('remove_pressable_branding_tab_options');
-        $branding_disabled = $opts && 'disable' === $opts['branding_on_off_radio_button'];
+        $branding_disabled = is_array( $opts )
+            && isset( $opts['branding_on_off_radio_button'] )
+            && 'disable' === $opts['branding_on_off_radio_button'];
 
         if ( $branding_disabled ) {
             // Branding hidden: "Built with ♥" — heart links to branding settings page

--- a/admin/settings-register.php
+++ b/admin/settings-register.php
@@ -32,7 +32,7 @@ function pressable_cache_management_register_settings()
 
     $remove_pressable_branding_tab_options = get_option('remove_pressable_branding_tab_options');
 
-    if ($remove_pressable_branding_tab_options && 'disable' == $remove_pressable_branding_tab_options['branding_on_off_radio_button']) {
+    if ( is_array( $remove_pressable_branding_tab_options ) && isset( $remove_pressable_branding_tab_options['branding_on_off_radio_button'] ) && 'disable' === $remove_pressable_branding_tab_options['branding_on_off_radio_button'] ) {
         add_settings_section(
             'pressable_cache_management_section_cache',
             esc_html__('Cache Control Management', 'pressable_cache_management'),

--- a/admin/settings-validate.php
+++ b/admin/settings-validate.php
@@ -15,40 +15,40 @@ function pressable_cache_management_callback_validate_options($input) {
     if (!isset($input["extend_batcache_checkbox"])) {
         $input["extend_batcache_checkbox"] = "";
     }
-    $input["extend_batcache_checkbox"] = filter_var($input["extend_batcache_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["extend_batcache_checkbox"] = ( ! empty( $input["extend_batcache_checkbox"] ) ? 1 : 0 );
 
     // Flush object cache on theme and plugin update checkbox
     if (!isset($input["flush_cache_theme_plugin_checkbox"])) {
         $input["flush_cache_theme_plugin_checkbox"] = "";
     }
-    $input["flush_cache_theme_plugin_checkbox"] = filter_var($input["flush_cache_theme_plugin_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["flush_cache_theme_plugin_checkbox"] = ( ! empty( $input["flush_cache_theme_plugin_checkbox"] ) ? 1 : 0 );
 
     // Flush object cache on page and post update
     if (!isset($input["flush_cache_page_edit_checkbox"])) {
         $input["flush_cache_page_edit_checkbox"] = "";
     }
-    $input["flush_cache_page_edit_checkbox"] = filter_var($input["flush_cache_page_edit_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["flush_cache_page_edit_checkbox"] = ( ! empty( $input["flush_cache_page_edit_checkbox"] ) ? 1 : 0 );
 
     // Flush object cache on page and post delete
     if (!isset($input["flush_cache_on_page_post_delete_checkbox"])) {
         $input["flush_cache_on_page_post_delete_checkbox"] = "";
     }
-    $input["flush_cache_on_page_post_delete_checkbox"] = filter_var($input["flush_cache_on_page_post_delete_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["flush_cache_on_page_post_delete_checkbox"] = ( ! empty( $input["flush_cache_on_page_post_delete_checkbox"] ) ? 1 : 0 );
 
     // Flush object cache on comment delete
     if (!isset($input["flush_cache_on_comment_delete_checkbox"])) {
         $input["flush_cache_on_comment_delete_checkbox"] = "";
     }
-    $input["flush_cache_on_comment_delete_checkbox"] = filter_var($input["flush_cache_on_comment_delete_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["flush_cache_on_comment_delete_checkbox"] = ( ! empty( $input["flush_cache_on_comment_delete_checkbox"] ) ? 1 : 0 );
 
     // Flush Batcache for individual page
     if (!isset($input["flush_object_cache_for_single_page"])) {
         $input["flush_object_cache_for_single_page"] = "";
     }
-    $input["flush_object_cache_for_single_page"] = filter_var($input["flush_object_cache_for_single_page"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT);
+    $input["flush_object_cache_for_single_page"] = ( ! empty( $input["flush_object_cache_for_single_page"] ) ? 1 : 0 );
 
     // Flush Batcache for WooCommerce individual page
-    $input["flush_batcache_for_woo_product_individual_page_checkbox"] = isset($input["flush_batcache_for_woo_product_individual_page_checkbox"]) ? filter_var($input["flush_batcache_for_woo_product_individual_page_checkbox"] == 1 ? 1 : 0, FILTER_SANITIZE_NUMBER_INT) : 0;
+    $input["flush_batcache_for_woo_product_individual_page_checkbox"] = isset($input["flush_batcache_for_woo_product_individual_page_checkbox"]) ? ( ! empty( $input["flush_batcache_for_woo_product_individual_page_checkbox"] ) ? 1 : 0 ) : 0;
 
     // Exclude pages from Batcache — sanitize comma-separated URL paths
     if ( isset( $input['exempt_from_batcache'] ) ) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,44 @@
 === Pressable Cache Management Change log ===
 
+= Version 6.2.0 (Mar 18, 2026) =
+
+**Security — Critical**
+* Fixed CSRF vulnerability on all AJAX cache-flush handlers — nonces are now generated and verified with check_ajax_referer() on every request
+* Added current_user_can('manage_options') authorization to legacy pressable_cache_purge_callback() which previously allowed any logged-in user to flush object cache
+* Added capability check to Edge Cache enable/disable handlers — previously any authenticated user with a valid nonce could toggle Edge Cache
+* Fixed targeted Batcache invalidation bug — wp_cache_set() was passing the cache group as the value argument instead of the group argument, causing single-page flushes to silently fail on distributed cache deployments
+
+**Security — High**
+* Hardened admin notice helpers with wp_kses_post() for message content and esc_attr() for CSS class values to prevent stored XSS
+* Replaced raw HTML echo in pcm_branded_notice() with wp_kses_post() filtering
+* Escaped all dynamic HTML attributes (name, id, for, value) in settings callback markup
+* Fixed malformed HTML: broken hidden input tag, duplicate name attributes on radio buttons, missing closing quotes on for/class attributes
+* Replaced role-name authorization checks (current_user_can('administrator'), current_user_can('editor')) with proper capability checks (manage_options, edit_posts, manage_woocommerce) across all handlers
+
+**PHP 8.1 Compatibility**
+* Removed deprecated FILTER_SANITIZE_NUMBER_INT — replaced with simple boolean normalization for all 7 checkbox validations
+* Replaced all date() calls with gmdate() and removed date_default_timezone_set()/date_default_timezone_get() timezone mutation pattern
+* Standardized timestamp format to 'j M Y, g:ia UTC' across all flush actions
+* Added is_array() and isset() guards before array access on option values to prevent PHP 8.1 warnings
+* Updated plugin header from Requires PHP: 7.4 to Requires PHP: 8.1
+
+**Security — Medium**
+* Added nonce verification to Edge Cache status and Defensive Mode status AJAX endpoints
+* Converted all state-changing AJAX requests from GET to POST (toolbar flush, column flush)
+* Replaced die(json_encode()) with wp_send_json_success()/wp_send_json_error() for consistent response handling
+* Added ABSPATH direct-access guards to flush-cache-on-comment-delete.php, remove-pressable-branding.php, wp-write-to-file-lib.php, and pcm-batcache-manager.php
+* Removed @ error suppression operators from file operations in flush-batcache-for-woo-individual-page.php and wp-write-to-file-lib.php
+
+**Performance**
+* Replaced time() asset versioning with filemtime() for all CSS/JS enqueues — assets now cache properly in browsers
+* Removed third-party Google Fonts dependency — settings page now uses system font stack
+* Removed blocking sleep(2) call from Edge Cache purge flow
+
+**Maintenance**
+* Fixed remove-old-mu-plugins.php migration to run once (keyed on pcm_migration_version option) instead of on every admin page load
+* Replaced insecure uniqid(mt_rand()) temporary filename generation with wp_unique_filename()
+* Simplified remove-pressable-branding.php — removed confusing array-to-string-to-array mutation pattern
+
 = Version 6.1.1 (Mar 17, 2026) =
 
 **Filename Standardization**

--- a/pressable-cache-management.php
+++ b/pressable-cache-management.php
@@ -7,7 +7,7 @@ Author:       Pressable CS Team
 Version:      6.1.0
 Requires at least: 5.0
 Tested up to: 6.7
-Requires PHP: 7.4
+Requires PHP: 8.1
 Text Domain:  pressable_cache_management
 Domain Path:  /languages
 License:      GPL v2 or later

--- a/remove-old-mu-plugins.php
+++ b/remove-old-mu-plugins.php
@@ -10,9 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit();
 }
 
-// Check if this particular plugin  version is updated.
-$current_version = '3.4.4';
-if ( version_compare( $current_version, '3.4.4', '>=' ) ) {
+// Run legacy cleanup only once — 6.1.0 adds the underscore file cleanup pass.
+$pcm_migration_version = get_option( 'pcm_migration_version', '0' );
+$pcm_migration_target  = '6.1.0';
+if ( version_compare( $pcm_migration_version, $pcm_migration_target, '<' ) ) {
 
 	// Library that writes/removes the batcache function to wp-config.php.
 	require_once plugin_dir_path( __FILE__ ) . 'admin/custom-functions/wp-write-to-file-lib.php';
@@ -20,10 +21,7 @@ if ( version_compare( $current_version, '3.4.4', '>=' ) ) {
 	/*
 	 * Remove Batcache extending.
 	 * Remove Batcache extending from wp-config.php file.
-	*/
-
-	$delete_config_file = true;
-
+	 */
 	global $wp_rewrite;
 	$global_config_file = file_exists( ABSPATH . 'wp-config.php' ) ? ABSPATH . 'wp-config.php' : dirname( ABSPATH ) . '/wp-config.php';
 
@@ -31,53 +29,54 @@ if ( version_compare( $current_version, '3.4.4', '>=' ) ) {
 		$line = 'global $batcache; if ( is_object($batcache) ) { $batcache->max_age = 86400; $batcache->seconds = 3600;  };';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		if ( strpos( file_get_contents( $global_config_file ), $line ) !== false && ( ! is_writeable_wp_config( $global_config_file ) || ! wp_config_file_replace_line( 'global *\$batcache; if *\( *is_object', '', $global_config_file ) ) ) {
-			wp_die( esc_html( "Could not remove Extending Batcache settings from $global_config_file. Please edit that file and remove the line containing the function 'global  $batcache;'. Then refresh this page. orcontact Pressable Support for help" ) );
+			wp_die( esc_html( "Could not remove Extending Batcache settings from $global_config_file. Please edit that file and remove the line containing the function 'global  \$batcache;'. Then refresh this page or contact Pressable Support for help." ) );
 		}
 	}
-}
 
-/**
- * Removes mu-plugins from the old mu-plugins directory
- * to prevent any conflict due to the new mu-plugins folder
- * which is created to store mu-plugins
- */
+	/**
+	 * Removes mu-plugins from the old mu-plugins directory
+	 * to prevent any conflict due to the new mu-plugins folder
+	 * which is created to store mu-plugins.
+	 */
 
-// ── Legacy root-level mu-plugins (CDN era) ───────────────────────────────────
-$mu_plugins = array( 'cdn_exclude_specific_file.php', 'cdn_exclude_css.php', 'cdn_exclude_jpg_png_webp.php', 'cdn_exclude_js_json.php', 'cdn_extender.php' );
+	// Legacy root-level mu-plugins (CDN era).
+	$mu_plugins = array( 'cdn_exclude_specific_file.php', 'cdn_exclude_css.php', 'cdn_exclude_jpg_png_webp.php', 'cdn_exclude_js_json.php', 'cdn_extender.php' );
 
-// ── Legacy root-level mu-plugin (underscore era, replaced by pcm-batcache-manager.php) ─
-$mu_plugins[] = 'pcm_batcache_manager.php';
+	// Legacy root-level mu-plugin (underscore era, replaced by pcm-batcache-manager.php).
+	$mu_plugins[] = 'pcm_batcache_manager.php';
 
-global $wp_filesystem;
-if ( empty( $wp_filesystem ) ) {
-	require_once ABSPATH . '/wp-admin/includes/file.php';
-	WP_Filesystem();
-}
-
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-foreach ( $mu_plugins as $mu_plugin ) {
-	$file = WP_CONTENT_DIR . '/mu-plugins/' . $mu_plugin;
-	if ( $wp_filesystem->exists( $file ) ) {
-		$wp_filesystem->delete( $file );
+	global $wp_filesystem;
+	if ( empty( $wp_filesystem ) ) {
+		require_once ABSPATH . '/wp-admin/includes/file.php';
+		WP_Filesystem();
 	}
-}
 
-// ── Legacy underscore-named files inside mu-plugins/pressable-cache-management/ ─
-// Prior to v6.1.1 these were deployed with underscores; now deployed with hyphens.
-// Remove the old names so both versions don't load simultaneously on upgraded installs.
-$legacy_sub_mu_plugins = array(
-	'pcm_extend_batcache.php',
-	'pcm_exclude_pages_from_batcache.php',
-	'pcm_exclude_query_string_gclid.php',
-	'pcm_cache_wpp_cookies_pages.php',
-);
-
-$sub_dir = WP_CONTENT_DIR . '/mu-plugins/pressable-cache-management';
-if ( $wp_filesystem->is_dir( $sub_dir ) ) {
-	foreach ( $legacy_sub_mu_plugins as $legacy_file ) {
-		$path = $sub_dir . '/' . $legacy_file;
-		if ( $wp_filesystem->exists( $path ) ) {
-			$wp_filesystem->delete( $path );
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	foreach ( $mu_plugins as $mu_plugin ) {
+		$file = WP_CONTENT_DIR . '/mu-plugins/' . $mu_plugin;
+		if ( $wp_filesystem->exists( $file ) ) {
+			$wp_filesystem->delete( $file );
 		}
 	}
+
+	// Legacy underscore-named files inside mu-plugins/pressable-cache-management/.
+	// Remove the old names so both versions do not load simultaneously on upgraded installs.
+	$legacy_sub_mu_plugins = array(
+		'pcm_extend_batcache.php',
+		'pcm_exclude_pages_from_batcache.php',
+		'pcm_exclude_query_string_gclid.php',
+		'pcm_cache_wpp_cookies_pages.php',
+	);
+
+	$sub_dir = WP_CONTENT_DIR . '/mu-plugins/pressable-cache-management';
+	if ( $wp_filesystem->is_dir( $sub_dir ) ) {
+		foreach ( $legacy_sub_mu_plugins as $legacy_file ) {
+			$path = $sub_dir . '/' . $legacy_file;
+			if ( $wp_filesystem->exists( $path ) ) {
+				$wp_filesystem->delete( $path );
+			}
+		}
+	}
+
+	update_option( 'pcm_migration_version', $pcm_migration_target );
 }


### PR DESCRIPTION
Addresses all P0 (Critical), P1 (High), and most P2/P3 findings from the full plugin security audit. Key fixes:

- CSRF protection on all AJAX cache-flush handlers (nonces + check_ajax_referer)
- Authorization added to legacy flush handler and Edge Cache toggle
- Targeted Batcache invalidation bug fixed (wp_cache_set wrong arguments)
- XSS hardening on notice helpers and branded notice raw HTML mode
- Role-name checks replaced with capability-based authorization
- PHP 8.1: removed FILTER_SANITIZE_NUMBER_INT, date()/timezone mutation, unsafe array access; bumped Requires PHP to 8.1
- All mutating AJAX converted from GET to POST
- Asset versioning changed from time() to filemtime()
- Removed Google Fonts dependency, blocking sleep(2), @ error suppression
- Migration in remove-old-mu-plugins.php now runs once, not every request
- Tested on a few Pressable hosted sites (WooCommerce and non-WooCommerce based)